### PR TITLE
Improve imports in shortcuts extension

### DIFF
--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -1,7 +1,6 @@
 import sys
 
-from peewee import *
-from peewee import Alias
+from peewee import Alias, Field, ForeignKeyField
 
 if sys.version_info[0] == 3:
     from collections import Callable


### PR DESCRIPTION
Improve the imports in this file.

First statement use wildcard import (and this is bad) and second import something already imported.

Import only required objects is the good way to do.